### PR TITLE
Expose download_path as a settable variable

### DIFF
--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -34,7 +34,7 @@ Initialise(){
       download_temp_path="$(mktemp --directory)"
       download_path="${download_temp_path}"
    else
-      download_path="/home/${user}/iCloud"
+      ${download_path:="/home/${user}/iCloud"}
    fi
    echo "$(date '+%Y-%m-%d %H:%M:%S') INFO     Local group: ${group:=group}:${group_id:=1000}"
    echo "$(date '+%Y-%m-%d %H:%M:%S') INFO     Force GID: ${force_gid:=False}"


### PR DESCRIPTION
This is for cases where users want to pass in ":ro" or otherwise avoid dumping the entire iCloud/* folder as one volume. My use case is to map .mounted, python_keyring, and cookie file as separate volume entries in the docker-compose file.