### PR TITLE
Please check change.log

### DIFF
--- a/change.log
+++ b/change.log
@@ -1,4 +1,8 @@
-20210809
+20210712
+
+ - Change: Modify 20210709 JSON escaping and correct change.log date
+
+20210709
 
  - Change: Changed JSON escaping to prevent further issues.
 

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -123,7 +123,7 @@ ConfigureNotifications(){
          notification_url="${webhook_scheme}://${webhook_server}:${webhook_port}${webhook_path}${webhook_id}"
          echo "$(date '+%Y-%m-%d %H:%M:%S') INFO     ${notification_type} notification URL: ${notification_url}"
          echo "$(date '+%Y-%m-%d %H:%M:%S') INFO     Notification period: ${notification_days=7}"
-         webhook_payload="$(echo -e "${notification_title} - iCloud\\Photos\\Downloader container started for Apple ID ${apple_id}")"
+         webhook_payload="$(echo -e "${notification_title} - iCloud\\\\\Photos\\\\\Downloader container started for Apple ID ${apple_id}")"
          Notify "startup" "${webhook_payload}"
       elif [ "${notification_type}" = "Dingtalk" ]&& [ "${dingtalk_token}" ]; then
          notification_url="https://oapi.dingtalk.com/robot/send?access_token=${dingtalk_token}"


### PR DESCRIPTION
@baccula  / @boredazfcuk  - Unless I'm missing something, the code in #74 doesn't work. Due to echo -e 2 backslashes is the same as a single backslash being passed to Notify, and the POST json string is still invalid. 

![image](https://user-images.githubusercontent.com/13224936/125344105-e11c7b00-e324-11eb-80bd-80555d383406.png)

This is invalid:
![image](https://user-images.githubusercontent.com/13224936/125344126-e8dc1f80-e324-11eb-8d36-35810f7a9cf4.png)

The proper fix should have 5 backslashes  - PR Submitted.

![image](https://user-images.githubusercontent.com/13224936/125344791-b7178880-e325-11eb-8a9e-c92f0b6486aa.png)

![image](https://user-images.githubusercontent.com/13224936/125344823-c26ab400-e325-11eb-8447-f0f5a27e65cf.png)

![image](https://user-images.githubusercontent.com/13224936/125344909-e0d0af80-e325-11eb-8f8d-c34d9555ecf3.png)




