### PR TITLE
ignore custom path when trying change permissions.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -81,6 +81,8 @@ When the container is first started, it will write a default configuration file 
 
 **synology_photos_app_fix**: Set this to **true** to touch files after download and trigger the Synology Photos app to index any newly created files.
 
+**synology_ignore_path**: Set this to "**\*/@eaDir\***" to avoid huge warnings when trying to change permissions under Synology system.
+
 **single_pass**: Set this to **true** to exit out after a single pass instead of looping as per the synchronisation_interval. If this option is used, it will automatically disable the download check. If using this configuration option, the restart policy of the container must be set to "no". If it is set to "always" then the container will instantly relaunch after the first run and you will hammer Apple's website.
 
 # NEXTCLOUD CONFIGURATION VARIABLES

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -81,7 +81,7 @@ When the container is first started, it will write a default configuration file 
 
 **synology_photos_app_fix**: Set this to **true** to touch files after download and trigger the Synology Photos app to index any newly created files.
 
-**synology_ignore_path**: Set this to "**\*/@eaDir\***" to avoid huge warnings when trying to change permissions under Synology system.
+**synology_ignore_path**: Set this to **true** to avoid huge warnings when trying to change **@eaDir** permissions under Synology system.
 
 **single_pass**: Set this to **true** to exit out after a single pass instead of looping as per the synchronisation_interval. If this option is used, it will automatically disable the download check. If using this configuration option, the restart policy of the container must be set to "no". If it is set to "always" then the container will instantly relaunch after the first run and you will hammer Apple's website.
 

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -817,13 +817,13 @@ SetOwnerAndPermissionsConfig(){
 
 SetOwnerAndPermissionsDownloads(){
    LogDebug "Set owner on iCloud directory, if required"
-   find "${download_path}" ! -type l ! -user "${user_id}" -exec chown "${user_id}" {} +
+   find "${download_path}" ! -type l ! -user "${user_id}" ! -path "${synology_ignore_path}" -exec chown "${user_id}" {} +
    LogDebug "Set group on iCloud directory, if required"
-   find "${download_path}" ! -type l ! -group "${group_id}" -exec chgrp "${group_id}" {} +
+   find "${download_path}" ! -type l ! -group "${group_id}" ! -path "${synology_ignore_path}" -exec chgrp "${group_id}" {} +
    LogDebug "Set ${directory_permissions} permissions on iCloud directories, if required"
-   find "${download_path}" -type d ! -perm "${directory_permissions}" -exec chmod "${directory_permissions}" '{}' +
+   find "${download_path}" -type d ! -perm "${directory_permissions}" ! -path "${synology_ignore_path}" -exec chmod "${directory_permissions}" '{}' +
    LogDebug "Set ${file_permissions} permissions on iCloud files, if required"
-   find "${download_path}" -type f ! -perm "${file_permissions}" -exec chmod "${file_permissions}" '{}' +
+   find "${download_path}" -type f ! -perm "${file_permissions}" ! -path "${synology_ignore_path}" -exec chmod "${file_permissions}" '{}' +
 }
 
 CheckWebCookie(){

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -817,13 +817,18 @@ SetOwnerAndPermissionsConfig(){
 
 SetOwnerAndPermissionsDownloads(){
    LogDebug "Set owner on iCloud directory, if required"
-   find "${download_path}" ! -type l ! -user "${user_id}" ! -path "${synology_ignore_path}" -exec chown "${user_id}" {} +
+   if [ "${synology_ignore_path:=false}" = true ]; then
+      ignore_path="*/@eaDir*"
+   else
+      ignore_path=""
+   fi
+   find "${download_path}" ! -type l ! -user "${user_id}" ! -path "${ignore_path}" -exec chown "${user_id}" {} +
    LogDebug "Set group on iCloud directory, if required"
-   find "${download_path}" ! -type l ! -group "${group_id}" ! -path "${synology_ignore_path}" -exec chgrp "${group_id}" {} +
+   find "${download_path}" ! -type l ! -group "${group_id}" ! -path "${ignore_path}" -exec chgrp "${group_id}" {} +
    LogDebug "Set ${directory_permissions} permissions on iCloud directories, if required"
-   find "${download_path}" -type d ! -perm "${directory_permissions}" ! -path "${synology_ignore_path}" -exec chmod "${directory_permissions}" '{}' +
+   find "${download_path}" -type d ! -perm "${directory_permissions}" ! -path "${ignore_path}" -exec chmod "${directory_permissions}" '{}' +
    LogDebug "Set ${file_permissions} permissions on iCloud files, if required"
-   find "${download_path}" -type f ! -perm "${file_permissions}" ! -path "${synology_ignore_path}" -exec chmod "${file_permissions}" '{}' +
+   find "${download_path}" -type f ! -perm "${file_permissions}" ! -path "${ignore_path}" -exec chmod "${file_permissions}" '{}' +
 }
 
 CheckWebCookie(){


### PR DESCRIPTION
There were huge warning logs in the docker under Synology, because the thumbnail directory `@eaDir` was generated by root user, so there is no permission when changing its owner or mod.

Some of them are symbol files that can be filtered by **-type l**, but not all.
```
-rwxrwxrwx+  1 root users    475 Jul  7 15:45 SYNOINDEX_MEDIA_INFO
-rwxrwxrwx+  1 root users     79 Jul  7 15:45 SYNOINDEX_VIDEO_METADATA
lrwxrwxrwx   1 root root      24 Jul  7 15:45 SYNOPHOTO_FILM_H264.mp4 -> ../../sd1688286568_2.mp4
-rw-r--r--   1 root root   25597 Jul  7 15:45 SYNOPHOTO_THUMB_M.jpg
-rw-r--r--   1 root root   16920 Jul  7 15:45 SYNOPHOTO_THUMB_SM.jpg
-rw-r--r--   1 root root  166929 Jul  7 15:45 SYNOPHOTO_THUMB_XL.jpg
```

And we actually should not change its permission.

So I want to add an environment variable to allow user to customize ignore path, for example `*/@eaDir*` to avoid these warnings.