### PR TITLE
Add jpeg package to app_deps to fix #474

### DIFF
--- a/icloudpd.dockerfile
+++ b/icloudpd.dockerfile
@@ -6,7 +6,7 @@ ENV config_dir="/config" XDG_DATA_HOME="/config" TZ="UTC"
 ARG icloudpd_version="1.17.3"
 ARG python_version="3.11"
 ARG build_dependencies="git gcc python3-dev musl-dev rust cargo libffi-dev openssl-dev"
-ARG app_dependencies="py3-pip exiftool coreutils tzdata curl imagemagick shadow jq libheif bind-tools"
+ARG app_dependencies="py3-pip exiftool coreutils tzdata curl imagemagick shadow jq libheif jpeg bind-tools"
 ARG fix_repo="boredazfcuk/icloud_photos_downloader"
 
 RUN echo "$(date '+%d/%m/%Y - %H:%M:%S') | ***** Build started for boredazfcuk's docker-icloudpd *****" && \


### PR DESCRIPTION
Fixes #474 by adding required jpeg package to allow imagemagick to convert heic files to jpeg. 

Confirmed the latest pull (v711) on main that the issue still existed and can be fixed by adding the jpeg package via ```apk add jpeg```.  This PR addresses that need. 