### PR TITLE
Add gotify_https variable to sync-icloud.sh for http/https Gotify servers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -180,6 +180,8 @@ When the container is first started, it will write a default configuration file 
 
 **gotify_server_url**: Mandatory if notification_type set to 'Gotify'. This is the server name of your Gotify server e.g. server.domain.tld
 
+**gotify_https**: If this is set to 'True' then the Gotify server URL will use HTTPS, otherwise it will default to HTTP.
+
 **bark_device_key**: Mandatory if notification_type set to 'Bark'. This is the device key associated with your device
 
 **bark_server**: Mandatory if notification_type set to 'Bark'. This is the name of your Bark server, including the port. Please note that inculding the port seems to be mandatory for Bark. e.g. https://server.domain.com:443: or http://127.16.0.1:80. Failure to include the http/https prefix with result in error code 400 and failure to include the port will result in a 000 error.

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -24,6 +24,8 @@ initialise_config_file(){
       if [ "$(grep -c "file_permissions=" "${config_file}")" -eq 0 ]; then echo file_permissions="${file_permissions:=640}"; fi
       if [ "$(grep -c "folder_structure=" "${config_file}")" -eq 0 ]; then echo folder_structure="${folder_structure:={:%Y/%m/%d\}}"; fi
       if [ "$(grep -c "gotify_app_token=" "${config_file}")" -eq 0 ]; then echo gotify_app_token="${gotify_app_token}"; fi
+      if [ "$(grep -c "gotify_server_url=" "${config_file}")" -eq 0 ]; then echo gotify_server_url="${gotify_server_url}"; fi
+      if [ "$(grep -c "gotify_https=" "${config_file}")" -eq 0 ]; then echo gotify_https="${gotify_https}"; fi
       if [ "$(grep -c "group=" "${config_file}")" -eq 0 ]; then echo group="${group:=group}"; fi
       if [ "$(grep -c "group_id=" "${config_file}")" -eq 0 ]; then echo group_id="${group_id:=1000}"; fi
       if [ "$(grep -c "icloud_china=" "${config_file}")" -eq 0 ]; then echo icloud_china="${icloud_china}"; fi
@@ -109,6 +111,8 @@ initialise_config_file(){
       sed -i "s@^folder_structure=.*@folder_structure=${sanitised_folder_structure}@" "${config_file}"
    fi
    if [ "${gotify_app_token}" ]; then sed -i "s%^gotify_app_token=.*%gotify_app_token=${gotify_app_token}%" "${config_file}"; fi
+   if [ "${gotify_server_url}" ]; then sed -i "s%^gotify_server_url=.*%gotify_server_url=${gotify_server_url}%" "${config_file}"; fi
+   if [ "${gotify_https}" ]; then sed -i "s%^gotify_https=.*%gotify_https=${gotify_https}%" "${config_file}"; fi
    if [ "${group}" ]; then sed -i "s%^group=.*%group=${group}%" "${config_file}"; fi
    if [ "${group_id}" ]; then sed -i "s%^group_id=.*%group_id=${group_id}%" "${config_file}"; fi
    if [ "${icloud_china}" ]; then sed -i "s%^icloud_china=.*%icloud_china=${icloud_china}%" "${config_file}"; fi
@@ -636,6 +640,11 @@ ConfigureNotifications(){
             LogInfo "${notification_type} notification URL: ${notification_url}"
          fi
       elif [ "${notification_type}" = "Gotify" -a "${gotify_app_token}" -a "${gotify_server_url}" ]; then
+      if [ "${gotify_https}" = true ]; then
+            gotify_scheme="https"
+         else
+            gotify_scheme="http"
+         fi
          LogInfo "${notification_type} notifications enabled"
          CleanNotificationTitle
          if [ "${debug_logging}" = true ]; then
@@ -645,7 +654,7 @@ ConfigureNotifications(){
             LogInfo "${notification_type} token: ${gotify_app_token}"
             LogInfo "${notification_type} server URL: ${gotify_server_url}"
          fi
-         notification_url="https://${gotify_server_url}/message?token=${gotify_app_token}"
+         notification_url="${gotify_scheme}://${gotify_server_url}/message?token=${gotify_app_token}"
       elif [ "${notification_type}" = "Bark" -a "${bark_device_key}" -a "${bark_server}" ]; then
          LogInfo "${notification_type} notifications enabled"
          CleanNotificationTitle
@@ -659,7 +668,7 @@ ConfigureNotifications(){
          notification_url="http://${bark_server}/push"
       else
          LogWarning "$(date '+%Y-%m-%d %H:%M:%S') WARINING ${notification_type} notifications enabled, but configured incorrectly - disabling notifications"
-         unset notification_type prowl_api_key pushover_user pushover_token telegram_token telegram_chat_id webhook_scheme webhook_server webhook_port webhook_id dingtalk_token discord_id discord_token iyuu_token wecom_id wecom_secret gotify_app_token gotify_server_url bark_device_key bark_server
+         unset notification_type prowl_api_key pushover_user pushover_token telegram_token telegram_chat_id webhook_scheme webhook_server webhook_port webhook_id dingtalk_token discord_id discord_token iyuu_token wecom_id wecom_secret gotify_app_token gotify_scheme gotify_server_url bark_device_key bark_server
       fi
 
       if [ "${startup_notification:=true}" = true ]; then


### PR DESCRIPTION
Per issue #492 added a Docker env variable (gotify_https) similar to the webhook_https variable. This adds a gotify_scheme variable (http or https) to the beginning of a url request to the Gotify server. It defaults to false (http), but it can be set to true to enable https. This allows self-hosted Gotify instances without SSL or https to still function with the Gotify notifications by setting gotify_https to false.