### PR TITLE
fix: wecom curl get togen fail

### DIFF
--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -1716,7 +1716,7 @@ Notify(){
          fi
       fi
       LogInfo "Attempting send..."
-      notification_result="$(curl --silent --output /dev/null --write-out "%{http_code}" --user_agent "${user_agent}" --data-ascii "{\"touser\":\"${touser}\",\"msgtype\":\"mpnews\",\"agentid\":\"${agentid}\",\"mpnews\":{\"articles\":[{\"title\":\"${notification_wecom_title}\",\"thumb_media_id\":\"${thumb_media_id}\",\"author\":\"${syn_end_time}\",\"content_source_url\":\"${content_source_url}\",\"content\":\"${wecom_text}\",\"digest\":\"${notification_wecom_digest}\"}]},\"safe\":\"0\",\"enable_id_trans\":\"0\",\"enable_duplicate_check\":\"0\",\"duplicate_check_interval\":\"1800\"}" --url "${notification_url}")"
+      notification_result="$(curl --silent --output /dev/null --write-out "%{http_code}" --user-agent "${user_agent}" --data-ascii "{\"touser\":\"${touser}\",\"msgtype\":\"mpnews\",\"agentid\":\"${agentid}\",\"mpnews\":{\"articles\":[{\"title\":\"${notification_wecom_title}\",\"thumb_media_id\":\"${thumb_media_id}\",\"author\":\"${syn_end_time}\",\"content_source_url\":\"${content_source_url}\",\"content\":\"${wecom_text}\",\"digest\":\"${notification_wecom_digest}\"}]},\"safe\":\"0\",\"enable_id_trans\":\"0\",\"enable_duplicate_check\":\"0\",\"duplicate_check_interval\":\"1800\"}" --url "${notification_url}")"
       curl_exit_code="$?"
       LogInfo "Send result: ${notification_result}"
    elif [ "${notification_type}" = "Gotify" ]; then


### PR DESCRIPTION
Because wechat official restrictions after June 20, 2022, enterprises need to have a fixed public IP address to access wechat;
Through the nginx proxy news push domain name to https://qyapi.weixin.qq.com implementation;
However, I need to add a bot restriction to the nginx rule. If the user_agent in the curl GET message is curl, it will be blocked and a new user_agent needs to be provided.
It has been verified on my computer and can work normally.