### PR TITLE
Updated parameter name keep_recent_days to keep_icloud_recent_days

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -55,7 +55,7 @@ When the container is first started, it will write a default configuration file 
 
 **delete_after_download**: After a file is successfully downloaded it is moved to the Recenlty Deleted folder. This configuration option cannot be used in conjunction with **auto_delete**. Default: false.
 
-**keep_recent_days**: Used with **delete_after_download**. Set this to an integer number to only keep the most recent *n* number of days. Default: 0 (keep all).
+**keep_icloud_recent_days**: Set this to an integer number to only keep the most recent *n* number of days. Setting this to 0 will remove all photos from iCloud. This configuration option cannot be used in conjunction with **delete_after_download**. Default: None (keep all).
 
 **photo_size**: Image size to download. Can be set to **original**, **medium**, **thumb**, **adjusted**, **alternative** or any combination of those five in a comma-separated string if multiple size types are to be downloaded e.g. **photo_size=original,adjusted**. Adjusted are the edited photos that can be made by using filters, or by using the markup tool in the Photos app. Alternative are RAW file types. Default: original.
 

--- a/change.log
+++ b/change.log
@@ -1,3 +1,7 @@
+07/01/2025
+
+ - Updated parameter name **keep_recent_days** to **keep_icloud_recent_days**.
+
 06/01/2025
 
  - Changed some IFS declarations so they're all consistent (echo \b\n to $'\n')
@@ -5,7 +9,7 @@
 
 05/01/2025
 
- - Added **keep_recent_days** option.
+ - Added **keep_icloud_recent_days** option.
 
 04/01/2025
 

--- a/init_config.sh
+++ b/init_config.sh
@@ -77,9 +77,9 @@ fi
    then
       echo delete_after_download="${delete_after_download:=false}"
    fi
-      if [ "$(grep -c "^keep_recent_days=" "${config_file}")" -eq 0 ]
+   if [ "$(grep -c "^keep_icloud_recent_days=" "${config_file}")" -eq 0 ]
    then
-      echo keep_recent_days="${keep_recent_days:=0}"
+      echo keep_icloud_recent_days="${keep_icloud_recent_days:=0}"
    fi
    if [ "$(grep -c "^delete_empty_directories=" "${config_file}")" -eq 0 ]
    then

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -245,7 +245,7 @@ initialise_script()
       sleep 120
       exit 1
    fi
-   log_info "Keep recent days: ${keep_recent_days}"
+   log_info "Keep iCloud recent days: ${keep_icloud_recent_days}"
    log_info "Delete empty directories: ${delete_empty_directories}"
    log_info "Photo size: ${photo_size}"
    log_info "Align RAW: ${align_raw}"
@@ -2309,9 +2309,9 @@ command_line_builder()
    then
       command_line="${command_line} --delete-after-download"
    fi
-   if [ "${keep_recent_days}" != 0 ]
+   if [ "${keep_icloud_recent_days}" != 0 ]
    then
-      command_line="${command_line} --keep-recent-days ${keep_recent_days}"
+      command_line="${command_line} --keep-icloud-recent-days ${keep_icloud_recent_days}"
    fi
    if [ "${skip_live_photos}" = false ]
    then


### PR DESCRIPTION
In #725 we added support for `--keep-recent-days`. Since a discussion around that parameter, it's been renamed to `--keep-icloud-recent-days` and its functionality has changed. This updates the name and the documentation around it.