### PR TITLE
fixed nextcloud_upload_library cannot open file for upload to nextcloud

### DIFF
--- a/change.log
+++ b/change.log
@@ -1,3 +1,6 @@
+22/02/2025
+ - Fixed --Upload-Library-To-Nextcloud curl 'unable to open file' error, so that the files are successfully uploaded to nextcloud
+
 20/02/2025
 
  - Launcher now checks that **download_path**, **jpeg_path** and **video_path** exist in /proc/mounts (if they are configured0. This should confirm that these directories are mounted to external locations at container launch. The .mounted file is still a requirement, as this makes sure the container is looking at the correct external mount and also that the volume hasn't dismounted due to errors.

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -1318,7 +1318,7 @@ nextcloud_upload_library()
       then
          echo "File already exsits"
       else
-         curl_response="$(curl --silent --show-error --location --user "${nextcloud_username}:${nextcloud_password}" --write-out "%{http_code}" --upload-file "${full_filename}" "${nextcloud_destination}")"
+         curl_response="$(curl --silent --show-error --location --user "${nextcloud_username}:${nextcloud_password}" --write-out "%{http_code}" --upload-file "${download_path}${full_filename}" "${nextcloud_destination}")"
          if [ "${curl_response}" -ge 200 ] && [ "${curl_response}" -le 299 ]
          then
             echo "Success"


### PR DESCRIPTION
This minor update adds the full filename path for the curl request in nextcloud_upload_library upload, as it was failing with the following error when the upload was attempted.

curl: cannot open '/2021/07/31/IMG20210731185927.JPG'
curl: try 'curl --help' or 'curl --manual' for more information
curl: (26) Failed to open/read local data from file/application
Unexpected response: 000