### PR TITLE
Fix jpeg_directory substitution duplication

### DIFF
--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -1528,7 +1528,7 @@ convert_all_heic_files()
       if [ "${jpeg_path}" ]
       then
          jpeg_file="${jpeg_file/${download_path}/${jpeg_path}}"
-         jpeg_directory="$(dirname "${jpeg_file/${download_path}/${jpeg_path}}")"
+         jpeg_directory="$(dirname "${jpeg_file}")"
          if [ ! -d "${jpeg_directory}" ]
          then
             mkdir --parents "${jpeg_directory}"
@@ -1595,7 +1595,7 @@ force_convert_all_heic_files()
       if [ "${jpeg_path}" ]
       then
          jpeg_file="${jpeg_file/${download_path}/${jpeg_path}}"
-         jpeg_directory="$(dirname "${jpeg_file/${download_path}/${jpeg_path}}")"
+         jpeg_directory="$(dirname "${jpeg_file}")"
          if [ ! -d "${jpeg_directory}" ]
          then
             mkdir --parents "${jpeg_directory}"

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -1356,7 +1356,7 @@ convert_downloaded_heic_to_jpeg()
          if [ "${jpeg_path}" ]
          then
             jpeg_file="${jpeg_file/${download_path}/${jpeg_path}}"
-            jpeg_directory="$(dirname "${jpeg_file/${download_path}/${jpeg_path}}")"
+            jpeg_directory="$(dirname "${jpeg_file}")"
             if [ ! -d "${jpeg_directory}" ]
             then
                mkdir --parents "${jpeg_directory}"


### PR DESCRIPTION
After replacing the download path with the JPEG path in the file variable, I noticed that the code was wrongly doing this substitution again when figuring out the directory. I removed this redundant second substitution by using the already-modified file path variable when determining the directory. This ensures the code now creates directories correctly and only when needed without any path duplication issues.