### PR TITLE
Add pushover_priority support for Pushover notifications

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -142,6 +142,8 @@ adds asset id from iCloud to all file names and does not need de-duplication. De
 
 **pushover_token**: Mandatory if notification_type set to 'Pushover'. This is the application API token. You will need to create an application by logging into your Pushover account and creating an application.
 
+**pushover_priority**: Mandatory if notification_type set to 'Pushover'. This is the priority of the notification. Valid values range from "-2" (lowest) to "1" (high) - priority "2" is not supported, as it requires additional parameters. Values for this variable can be found here: https://pushover.net/api#priority
+
 **pushover_sound**: Mandatory if notification_type set to 'Pushover' this variable can be set to customise the sound of the notification. Values for this variable can be found here: https://pushover.net/api#sounds
 
 **telegram_token**: Mandatory if notification_type set to 'Telegram'. This is the token that was assigned to your account by The Botfather.

--- a/change.log
+++ b/change.log
@@ -1,3 +1,7 @@
+15/04/2025
+
+- Added support for "pushover_priority" configuration (required when using Pushover notifications). Valid values are "-2" to "1". Priority "2" is intentionally unsupported due to additional API requirements.
+
 18/03/2025
 
  - Launcher now halts if both photo_album and photo_library are configured as these options conflict with each other

--- a/init_config.sh
+++ b/init_config.sh
@@ -207,6 +207,10 @@
    then
       echo prowl_api_key="${prowl_api_key}"
    fi
+   if [ "$(grep -c "^pushover_priority=" "${config_file}")" -eq 0 ]
+   then
+      echo pushover_priority="${pushover_priority}"
+   fi
    if [ "$(grep -c "^pushover_sound=" "${config_file}")" -eq 0 ]
    then
       echo pushover_sound="${pushover_sound}"
@@ -866,6 +870,10 @@ fi
 if [ "${prowl_api_key}" ]
 then
    sed -i "s%^prowl_api_key=.*%prowl_api_key=${prowl_api_key}%" "${config_file}"
+fi
+if [ "${pushover_priority}" ]
+then
+   sed -i "s%^pushover_priority=.*%pushover_priority=${pushover_priority}%" "${config_file}"
 fi
 if [ "${pushover_sound}" ]
 then

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -263,6 +263,17 @@ configure_notifications()
       log_info " | ${notification_type_tc} notifications enabled"
       log_debug "   - ${notification_type_tc} user: ${pushover_user:0:2}********${pushover_user:0-2}"
       log_debug "   - ${notification_type_tc} token: ${pushover_token:0:2}********${pushover_token:0-2}"
+      if [ -n "${pushover_priority}" ]
+      then
+         case "${pushover_priority}" in
+            -2|-1|0|1)
+               log_debug "   - ${notification_type_tc} priority: ${pushover_priority}"
+            ;;
+            *)
+               log_debug "   - ${notification_type_tc} priority '${pushover_priority}' is invalid. Using default (0)"
+               unset pushover_priority
+         esac
+      fi
       if [ "${pushover_sound}" ]
       then
          case "${pushover_sound}" in
@@ -1798,10 +1809,6 @@ send_notification()
       curl_exit_code="$?"
    elif [ "${notification_type}" = "pushover" ]
    then
-      if [ "${notification_prority}" = "2" ]
-      then
-         notification_prority=1
-      fi
       if [ "${notification_files_preview_count}" ]
       then
          pushover_text="$(echo -e "${notification_icon} ${notification_event}\n${notification_message}\nMost recent ${notification_files_preview_count} ${notification_files_preview_type} files:\n${notification_files_preview_text}")"
@@ -1812,8 +1819,8 @@ send_notification()
          --form-string "user=${pushover_user}" \
          --form-string "token=${pushover_token}" \
          --form-string "title=${notification_title}" \
+         --form-string "priority=${pushover_prority}" \
          --form-string "sound=${pushover_sound}" \
-         --form-string "priority=${notification_prority}" \
          --form-string "message=${pushover_text}")"
       curl_exit_code="$?"
    elif [ "${notification_type}" = "telegram" ]


### PR DESCRIPTION
### Summary

This PR introduces support for setting `pushover_priority` in the notification configuration when using Pushover.

### Changes

- Adds validation for `pushover_priority`, limited between -2 and 1
- Updates documentation with usage details
- Minor cleanup in `configure_notifications` function

### Why

To allow finer control over the importance of Pushover notifications, especially useful when differentiating quiet notifications from urgent ones.

### Notes

- Priority 2 (emergency) is not supported as it requires additional parameters (retry/expire).
- Default priority is 0 if not set or invalid, according Pushover documentation.

### Changelog

```plaintext
Added support for pushover_priority (values -2 to 1) for Pushover notifications.
