### PR TITLE
fix: correct typo in skip-created function

### DIFF
--- a/init_config.sh
+++ b/init_config.sh
@@ -152,7 +152,7 @@ write_variable silent_file_notifications false
 write_variable single_pass false
 write_variable skip_album
 write_variable skip_check false
-write_variable skip_created_afer
+write_variable skip_created_after
 write_variable skip_created_before
 write_variable skip_download false
 write_variable skip_library

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -2122,11 +2122,11 @@ command_line_builder()
    fi
    if [ "${skip_created_after}" ]
    then
-      command_line="${command_line} ----skip-created-after ${skip_created_after}"
+      command_line="${command_line} --skip-created-after ${skip_created_after}"
    fi
    if [ "${skip_created_before}" ]
    then
-      command_line="${command_line} ----skip-created-before ${skip_created_before}"
+      command_line="${command_line} --skip-created-before ${skip_created_before}"
    fi
 }
 


### PR DESCRIPTION
### Description
Fixed the typo in the `skip-created-after` and  `skip-created-before` function located in `sync-icloud.sh`.
In the meanwhile, fix the typo in `init_config.sh`

### Changes
- **inital config builder**: Corrected `skip-created-afer` to `skip-created-after`.
- **Command Builder**: Changed `----` prefix to `--` for proper argument parsing.

### Checklist
- [x] The code compiles/builds without errors.
- [x] No logic was changed, only spelling.
- [x] Verified the change doesn't break existing tests.