### PR TITLE
Fix --Initialise never prompting for password

### DIFF
--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -569,7 +569,7 @@ configure_password()
    fi
    if [ ! -f "/config/python_keyring/keyring_pass.cfg" ]
    then
-      if [ "${initialise_container}" ]
+      if [ "${action}" = "initialise_container" ]
       then
          log_debug "Adding password to keyring file: /config/python_keyring/keyring_pass.cfg"
          run_as "/opt/icloudpd/bin/icloud --username ${apple_id} --domain ${auth_domain}"


### PR DESCRIPTION
Fixes #863 

## Summary

`docker exec -it icloudpd sync-icloud.sh --Initialise` gets stuck at "Waiting for keyring file to be created..." and never prompts for the Apple ID password, making first-time container setup impossible through the documented workflow.

## Root Cause

In `configure_password()` (line 572), the condition checks the variable `${initialise_container}`:

```bash
if [ "${initialise_container}" ]
```

But this variable is never assigned anywhere. The `--Initialise` flag sets `action="initialise_container"` — that is, the variable `action` to the string `"initialise_container"` — not a variable named `initialise_container`.

Since `${initialise_container}` is always empty, the password prompt branch is never taken, and the script falls through to the `else` branch which loops waiting for a keyring file that can never be created.

## Fix

Change the check from testing an unset variable to testing `${action}` against the expected value:

```bash
if [ "${action}" = "initialise_container" ]
```

## Workaround

For anyone hitting this on existing containers, you can bypass the broken script and set up the keyring directly:

```bash
# Create the keyring directory
docker exec icloudpd mkdir -p /config/python_keyring
docker exec icloudpd chown user:group /config/python_keyring

# Run the icloud auth command directly (will prompt for password + 2FA)
docker exec -it icloudpd su user -s /bin/ash -c \
  "source /opt/icloudpd/bin/activate && icloud --username <your_apple_id> --domain com"

# Once the keyring is created, --Initialise works to generate the MFA cookie
docker exec -it icloudpd sync-icloud.sh --Initialise

# Restart the container
docker restart icloudpd
```