### PR TITLE
Make download_albums library-aware and handle album-not-found gracefully

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -424,8 +424,7 @@ then
 fi
 if [ "${photo_album}" ] && [ "${photo_library}" ]
 then
-   log_error "   | The variables photo_album and photo_library cannot both be configured at the same time. Please configure photo_album, photo_library or neither. Halting"
-   sleep infinity
+   log_info "   | Both photo_album and photo_library are configured. Albums will be downloaded from the specified library/libraries"
 fi
 
 # Display warning when using keep_icloud_recent

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -828,7 +828,40 @@ check_files()
    log_info "Check for new files using password stored in keyring file"
    log_info "Generating list of files in iCloud. This may take a long time if you have a large photo collection. Please be patient. Nothing is being downloaded at this time"
    >/tmp/icloudpd/icloudpd_check_error
-   if [ "${photo_library}" ]
+   if [ "${photo_album}" ] && [ "${photo_album}" != "all albums" ] && [ "${photo_library}" ]
+   then
+      local libraries_to_check album_arg
+      libraries_to_check="$(resolve_library_list)"
+      check_exit_code=0
+      local any_library_succeeded=false
+      IFS=","
+      for album_arg in ${photo_album}
+      do
+         for library in ${libraries_to_check}
+         do
+            log_debug "Checking album '${album_arg}' in library: ${library}"
+            log_debug "Launch command: /opt/icloudpd/bin/icloudpd --directory ${download_path} --cookie-directory /config --username ${apple_id} --domain ${auth_domain} --folder-structure ${folder_structure} --keep-unicode-in-filenames --only-print-filenames --library ${library} --album ${album_arg}"
+            >/tmp/icloudpd/icloudpd_check_error_tmp
+            run_as "(/opt/icloudpd/bin/icloudpd --directory ${download_path} --cookie-directory /config --username ${apple_id} --domain ${auth_domain} --folder-structure ${folder_structure} --keep-unicode-in-filenames --only-print-filenames --library \"${library}\" --album \"${album_arg}\" 2>/tmp/icloudpd/icloudpd_check_error_tmp; echo $? >/tmp/icloudpd/icloudpd_check_exit_code) | tee -a /tmp/icloudpd/icloudpd_check.log"
+            if grep -q "KeyError" /tmp/icloudpd/icloudpd_check_error_tmp 2>/dev/null
+            then
+               log_debug "Album '${album_arg}' not found in library '${library}', skipping"
+            elif [ -s /tmp/icloudpd/icloudpd_check_error_tmp ]
+            then
+               cat /tmp/icloudpd/icloudpd_check_error_tmp >> /tmp/icloudpd/icloudpd_check_error
+               check_exit_code=1
+            else
+               any_library_succeeded=true
+            fi
+         done
+      done
+      IFS="${OLDIFS}"
+      if [ "${any_library_succeeded}" = false ] && [ "${check_exit_code}" -eq 0 ]
+      then
+         check_exit_code=1
+         echo "Album(s) not found in any library" >> /tmp/icloudpd/icloudpd_check_error
+      fi
+   elif [ "${photo_library}" ]
    then
       local libraries_to_check
       libraries_to_check="$(resolve_library_list)"
@@ -847,6 +880,11 @@ check_files()
          fi
       done
       IFS="${OLDIFS}"
+   elif [ "${photo_album}" ] && [ "${photo_album}" != "all albums" ]
+   then
+      log_debug "Launch command: /opt/icloudpd/bin/icloudpd --directory ${download_path} --cookie-directory /config --username ${apple_id} --domain ${auth_domain} --folder-structure ${folder_structure} --keep-unicode-in-filenames --only-print-filenames --album ${photo_album}"
+      run_as "(/opt/icloudpd/bin/icloudpd --directory ${download_path} --cookie-directory /config --username ${apple_id} --domain ${auth_domain} --folder-structure ${folder_structure} --keep-unicode-in-filenames --only-print-filenames --album \"${photo_album}\" 2>/tmp/icloudpd/icloudpd_check_error; echo $? >/tmp/icloudpd/icloudpd_check_exit_code) | tee /tmp/icloudpd/icloudpd_check.log"
+      check_exit_code="$(cat /tmp/icloudpd/icloudpd_check_exit_code)"
    else
       log_debug "Launch command: /opt/icloudpd/bin/icloudpd --directory ${download_path} --cookie-directory /config --username ${apple_id} --domain ${auth_domain} --folder-structure ${folder_structure} --keep-unicode-in-filenames --only-print-filenames"
       run_as "(/opt/icloudpd/bin/icloudpd --directory ${download_path} --cookie-directory /config --username ${apple_id} --domain ${auth_domain} --folder-structure ${folder_structure} --keep-unicode-in-filenames --only-print-filenames 2>/tmp/icloudpd/icloudpd_check_error; echo $? >/tmp/icloudpd/icloudpd_check_exit_code) | tee /tmp/icloudpd/icloudpd_check.log"
@@ -946,6 +984,36 @@ deleted_files_notification()
    IFS="${OLDIFS}"
 }
 
+resolve_library_list()
+{
+   local all_libraries resolved_list
+   if [ "${photo_library}" = "all libraries" ]
+   then
+      log_debug "Fetching libraries list..." >&2
+      all_libraries="$(run_as "/opt/icloudpd/bin/icloudpd --username ${apple_id} --cookie-directory /config --domain ${auth_domain} --directory /dev/null --list-libraries" | sed '/^[0-9]/d' | sed '/^Libraries:$/d')"
+      log_debug "Building list of libraries..." >&2
+      IFS=$'\n'
+      for library in ${all_libraries}
+      do
+         if [ "${skip_library}" ] && [ "${skip_library}" = "${library}" ]
+         then
+            continue
+         fi
+         log_debug " - ${library}" >&2
+         if [ -z "${resolved_list}" ]
+         then
+            resolved_list="${library}"
+         else
+            resolved_list="${resolved_list},${library}"
+         fi
+      done
+      IFS="${OLDIFS}"
+   else
+      resolved_list="${photo_library}"
+   fi
+   echo "${resolved_list}"
+}
+
 download_albums()
 {
    local all_albums albums_to_download
@@ -985,56 +1053,81 @@ download_albums()
    log_debug "Starting albums download..."
    # Clear log file for the download list to append to
    echo "" > /tmp/icloudpd/icloudpd_sync.log
+   local libraries_to_download
+   if [ "${photo_library}" ]
+   then
+      libraries_to_download="$(resolve_library_list)"
+   fi
    for album in ${albums_to_download}
    do
       log_info "Downloading album: ${album}"
-      if [ "${albums_with_dates}" = true ]
+      if [ "${photo_library}" ]
       then
-         log_debug "iCloudPD launch command: /opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}/${folder_structure}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error"
-         run_as "(/opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}/${folder_structure}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error; echo $? >/tmp/icloudpd/icloudpd_download_exit_code) | tee -a /tmp/icloudpd/icloudpd_sync.log"
+         local album_found download_failed
+         album_found=false
+         download_failed=false
+         IFS=","
+         for library in ${libraries_to_download}
+         do
+            log_info "Downloading album '${album}' from library: ${library}"
+            if [ "${albums_with_dates}" = true ]
+            then
+               log_debug "iCloudPD launch command: /opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${library}/${album}/${folder_structure}\" --album \"${album}\" --library \"${library}\" 2>/tmp/icloudpd/icloudpd_download_error"
+               run_as "(/opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${library}/${album}/${folder_structure}\" --album \"${album}\" --library \"${library}\" 2>/tmp/icloudpd/icloudpd_download_error; echo $? >/tmp/icloudpd/icloudpd_download_exit_code) | tee -a /tmp/icloudpd/icloudpd_sync.log"
+            else
+               log_debug "iCloudPD launch command: /opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${library}/${album}\" --album \"${album}\" --library \"${library}\" 2>/tmp/icloudpd/icloudpd_download_error"
+               run_as "(/opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${library}/${album}\" --album \"${album}\" --library \"${library}\" 2>/tmp/icloudpd/icloudpd_download_error; echo $? >/tmp/icloudpd/icloudpd_download_exit_code) | tee -a /tmp/icloudpd/icloudpd_sync.log"
+            fi
+            if grep -q "KeyError" /tmp/icloudpd/icloudpd_download_error 2>/dev/null
+            then
+               log_debug "Album '${album}' not found in library '${library}', skipping"
+               continue
+            elif [ -s /tmp/icloudpd/icloudpd_download_error ]
+            then
+               log_error "Failed downloading album '${album}' from library: ${library}"
+               download_failed=true
+               break
+            else
+               album_found=true
+            fi
+         done
+         if [ "${download_failed}" = true ]
+         then
+            IFS="${OLDIFS}"
+            sleep 10
+            break
+         fi
+         if [ "${album_found}" = false ]
+         then
+            log_error "Album '${album}' not found in any library"
+            echo 1 > /tmp/icloudpd/icloudpd_download_exit_code
+            echo "Album '${album}' not found in any library" > /tmp/icloudpd/icloudpd_download_error
+            IFS="${OLDIFS}"
+            sleep 10
+            break
+         fi
+         # Album downloaded from at least one library — mark success
+         echo 0 > /tmp/icloudpd/icloudpd_download_exit_code
+         >/tmp/icloudpd/icloudpd_download_error
       else
-         log_debug "iCloudPD launch command: /opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error"
-         run_as "(/opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error; echo $? >/tmp/icloudpd/icloudpd_download_exit_code) | tee -a /tmp/icloudpd/icloudpd_sync.log"
-      fi
-      if [ "$(cat /tmp/icloudpd/icloudpd_download_exit_code)" -ne 0 ]
-      then
-         log_error "Failed downloading album: ${album}"
-         IFS="${OLDIFS}"
-         sleep 10
-         break
+         if [ "${albums_with_dates}" = true ]
+         then
+            log_debug "iCloudPD launch command: /opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}/${folder_structure}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error"
+            run_as "(/opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}/${folder_structure}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error; echo $? >/tmp/icloudpd/icloudpd_download_exit_code) | tee -a /tmp/icloudpd/icloudpd_sync.log"
+         else
+            log_debug "iCloudPD launch command: /opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error"
+            run_as "(/opt/icloudpd/bin/icloudpd ${command_line} --log-level ${log_level} --folder-structure \"${album}\" --album \"${album}\" 2>/tmp/icloudpd/icloudpd_download_error; echo $? >/tmp/icloudpd/icloudpd_download_exit_code) | tee -a /tmp/icloudpd/icloudpd_sync.log"
+         fi
+         if [ "$(cat /tmp/icloudpd/icloudpd_download_exit_code)" -ne 0 ]
+         then
+            log_error "Failed downloading album: ${album}"
+            IFS="${OLDIFS}"
+            sleep 10
+            break
+         fi
       fi
    done
    IFS="${OLDIFS}"
-}
-
-resolve_library_list()
-{
-   local all_libraries resolved_list
-   if [ "${photo_library}" = "all libraries" ]
-   then
-      log_debug "Fetching libraries list..."
-      all_libraries="$(run_as "/opt/icloudpd/bin/icloudpd --username ${apple_id} --cookie-directory /config --domain ${auth_domain} --directory /dev/null --list-libraries | sed '1d'")"
-      log_debug "Building list of libraries..."
-      IFS=$'\n'
-      for library in ${all_libraries}
-      do
-         if [ "${skip_library}" ] && [ "${skip_library}" = "${library}" ]
-         then
-            continue
-         fi
-         log_debug " - ${library}"
-         if [ -z "${resolved_list}" ]
-         then
-            resolved_list="${library}"
-         else
-            resolved_list="${resolved_list},${library}"
-         fi
-      done
-      IFS="${OLDIFS}"
-   else
-      resolved_list="${photo_library}"
-   fi
-   echo "${resolved_list}"
 }
 
 download_libraries()


### PR DESCRIPTION
## Summary

When both `photo_album` and `photo_library` are configured, `download_albums()` now iterates libraries and passes `--library` to `icloudpd`, allowing albums to be downloaded from multiple libraries (e.g., PrimarySync and SharedSync). Previously, `photo_library` was completely ignored when `photo_album` was set.

- **New `resolve_library_list()` helper** — Extracted from `download_libraries()` inline logic. Handles "all libraries" enumeration with `--list-libraries`, `skip_library` filtering, and specific library passthrough. Used by `check_files()`, `download_albums()`, and `download_libraries()`.
- **`check_files()` restructured** into 4 cases: album+library (new), library-only, album-only (new), and default. The album+library case iterates each album × library combination, passing both `--album` and `--library` to `icloudpd`.
- **`download_albums()` gains library iteration** — When `photo_library` is set, each album is downloaded from each library with folder structure `{library}/{album}/...` to keep files separated.
- **Graceful KeyError handling** — When an album doesn't exist in a specific library, `icloudpd` throws a `KeyError`. This is now detected via stderr content and the library is skipped. Only if the album doesn't exist in *any* library is it treated as an error.
- **`launcher.sh` validation updated** — The check that blocked `photo_album` + `photo_library` from being configured together is replaced with an informational log message.

## Test plan

Tested on a live iCloud account:
- [x] `photo_album=Hidden` + `photo_library=all libraries` — `check_files` correctly enumerates 1,539 files across PrimarySync (19) and SharedSync (1,520)
- [x] Nonexistent album + `photo_library=all libraries` — Gracefully skips each library with debug message, then sets `check_exit_code=1` with "Album(s) not found in any library"
- [x] Syntax check passes (`bash -n sync-icloud.sh`)