### PR TITLE
Fix duplicate Telegram remote reauthentication flow

### DIFF
--- a/authenticate.exp
+++ b/authenticate.exp
@@ -24,6 +24,7 @@ expect {
         send_user "\nWaiting for MFA code...\n"
         exec >@stdout 2>@stderr /usr/bin/inotifywait -qq -t 600 -e close_write /tmp/icloudpd/expect_input.txt
         set MFACODE [exec cat /tmp/icloudpd/expect_input.txt]
+        exec /bin/sh -c ': > /tmp/icloudpd/expect_input.txt'
         set DATE [clock format [clock seconds] -format {%Y-%m-%d %H:%M:%S}]
         send_user "${DATE} INFO     MFA code received: ${MFACODE}\n"
         send -- "${MFACODE}\r"
@@ -47,6 +48,7 @@ expect {
         send_user "${DATE} INFO     Waiting for SMS choice/MFA code...\n"
         exec >@stdout 2>@stderr /usr/bin/inotifywait -qq -t 600 -e close_write /tmp/icloudpd/expect_input.txt
         set MESSAGE [exec cat /tmp/icloudpd/expect_input.txt]
+        exec /bin/sh -c ': > /tmp/icloudpd/expect_input.txt'
         set DATE [clock format [clock seconds] -format {%Y-%m-%d %H:%M:%S}]
         send_user "${DATE} INFO     SMS choice/MFA code received: ${MESSAGE}\n"
         send -- "${MESSAGE}\r"
@@ -70,6 +72,7 @@ expect {
                 send_user "${DATE} INFO     Waiting for MFA code...\n"
                 exec >@stdout 2>@stderr /usr/bin/inotifywait -qq -t 600 -e close_write /tmp/icloudpd/expect_input.txt
                 set MFACODE [exec cat /tmp/icloudpd/expect_input.txt]
+                exec /bin/sh -c ': > /tmp/icloudpd/expect_input.txt'
                 set DATE [clock format [clock seconds] -format {%Y-%m-%d %H:%M:%S}]
                 send_user "${DATE} INFO     MFA code received: ${MFACODE}\n"
                 send -- "${MFACODE}\r"

--- a/authenticate.exp
+++ b/authenticate.exp
@@ -24,7 +24,7 @@ expect {
         send_user "\nWaiting for MFA code...\n"
         exec >@stdout 2>@stderr /usr/bin/inotifywait -qq -t 600 -e close_write /tmp/icloudpd/expect_input.txt
         set MFACODE [exec cat /tmp/icloudpd/expect_input.txt]
-        exec /bin/sh -c ': > /tmp/icloudpd/expect_input.txt'
+        close [open /tmp/icloudpd/expect_input.txt w]
         set DATE [clock format [clock seconds] -format {%Y-%m-%d %H:%M:%S}]
         send_user "${DATE} INFO     MFA code received: ${MFACODE}\n"
         send -- "${MFACODE}\r"
@@ -48,7 +48,7 @@ expect {
         send_user "${DATE} INFO     Waiting for SMS choice/MFA code...\n"
         exec >@stdout 2>@stderr /usr/bin/inotifywait -qq -t 600 -e close_write /tmp/icloudpd/expect_input.txt
         set MESSAGE [exec cat /tmp/icloudpd/expect_input.txt]
-        exec /bin/sh -c ': > /tmp/icloudpd/expect_input.txt'
+        close [open /tmp/icloudpd/expect_input.txt w]
         set DATE [clock format [clock seconds] -format {%Y-%m-%d %H:%M:%S}]
         send_user "${DATE} INFO     SMS choice/MFA code received: ${MESSAGE}\n"
         send -- "${MESSAGE}\r"
@@ -72,7 +72,7 @@ expect {
                 send_user "${DATE} INFO     Waiting for MFA code...\n"
                 exec >@stdout 2>@stderr /usr/bin/inotifywait -qq -t 600 -e close_write /tmp/icloudpd/expect_input.txt
                 set MFACODE [exec cat /tmp/icloudpd/expect_input.txt]
-                exec /bin/sh -c ': > /tmp/icloudpd/expect_input.txt'
+                close [open /tmp/icloudpd/expect_input.txt w]
                 set DATE [clock format [clock seconds] -format {%Y-%m-%d %H:%M:%S}]
                 send_user "${DATE} INFO     MFA code received: ${MFACODE}\n"
                 send -- "${MFACODE}\r"

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -2435,20 +2435,27 @@ synchronise_user()
                            elif  [ "${check_update_text_lc}" = "${user_lc} auth" ]
                            then
                               log_debug "Remote authentication message match: ${check_update_text}"
-                              if [ "${icloud_china}" = "false" ]
+                              if [ "$(ps -ef | grep -c "[/]usr/bin/expect /opt/authenticate.exp")" -eq 0 ]
                               then
-                                 send_notification "remotesync" "iCloudPD remote download initiated" "0" "iCloudPD has detected a remote authentication request for Apple ID: ${apple_id}"
+                                 if [ "${icloud_china}" = "false" ]
+                                 then
+                                    send_notification "remotesync" "iCloudPD remote download initiated" "0" "iCloudPD has detected a remote authentication request for Apple ID: ${apple_id}"
+                                 else
+                                    send_notification "remotesync" "iCloudPD remote download initiated" "0" "iCloudPD将以Apple ID: ${apple_id}发起身份验证"
+                                 fi
+                                 rm -f "/config/${cookie_file}" "/config/${cookie_file}.session"
+                                 : > /tmp/icloudpd/expect_input.txt
+                                 rm -f /tmp/icloudpd/expect_error_flag
+                                 log_debug "Starting remote authentication process"
+                                 /usr/bin/expect /opt/authenticate.exp &
+                                 poll_sleep=3
                               else
-                                 send_notification "remotesync" "iCloudPD remote download initiated" "0" "iCloudPD将以Apple ID: ${apple_id}发起身份验证"
+                                 log_debug "Remote authentication already in progress, ignoring duplicate request"
                               fi
-			                     rm "/config/${cookie_file}" "/config/${cookie_file}.session"
-                              log_debug "Starting remote authentication process"
-                              /usr/bin/expect /opt/authenticate.exp &
-                              poll_sleep=3
                            elif [ "$(expr match "${check_update_text_lc}" "^${user_lc} [0-9][0-9][0-9][0-9][0-9][0-9]$" >/dev/null; echo $?)" -eq 0 ]
                            then
                               mfa_code="$(echo "${check_update_text}" | awk '{print $2}')"
-                              printf "%s\n" "${mfa_code}" >> /tmp/icloudpd/expect_input.txt
+                              printf "%s\n" "${mfa_code}" > /tmp/icloudpd/expect_input.txt
                               listen_counter=$((listen_counter+2))
                               # additional sleeps mean sync time slips each time time a sync or auth is performed
                               # adding same amount of time to listen counter should prevent this from occurring
@@ -2458,7 +2465,7 @@ synchronise_user()
                            elif [ "$(expr match "${check_update_text_lc}" "^${user_lc} [a-z]$" >/dev/null; echo $?)" -eq 0 ]
                            then
                               sms_choice="$(echo "${check_update_text}" | awk '{print $2}')"
-                              printf "%s\n" "${sms_choice}" >> /tmp/icloudpd/expect_input.txt
+                              printf "%s\n" "${sms_choice}" > /tmp/icloudpd/expect_input.txt
                               listen_counter=$((listen_counter+2))
                               # Same again
                               sleep 2


### PR DESCRIPTION
## Summary
Fix duplicate Telegram remote reauthentication handling.

## Changes
- ignore duplicate `user auth` requests while a reauthentication session is already running
- overwrite `/tmp/icloudpd/expect_input.txt` for SMS choice and MFA code input instead of appending
- clear the shared input file after each read in `authenticate.exp`
- remove cookie files with `rm -f` to avoid noisy errors during remote reauth

## Why
The current remote reauthentication flow can start multiple concurrent `authenticate.exp` sessions for the same Telegram command and appends both SMS choice and MFA code into the same input file. That leads to duplicated Telegram prompts and malformed input like `a\n123456`, which can produce a failure notification even when reauthentication later succeeds.

## Validation
- `bash -n sync-icloud.sh`
- reproduced the failure mode from the running container logs and aligned the fix to that code path
