### PR TITLE
Feature/Add msmtp sender display name and "To" header support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -225,6 +225,8 @@ If you use the official Bark server, please fill the field with `api.day.app`.
 
 **msmtp_from**: Mandatory if notification_type set to `msmtp`. The sender's email address
 
+**msmtp_from_name**: Optional if notification_type set to `msmtp`. The display name shown for the sender. For example, `iCloudPD`.
+
 **msmtp_user**: Mandatory if notification_type set to `msmtp`. The login username for your SMTP provider
 
 **msmtp_pass**: Mandatory if notification_type set to `msmtp`. The password for the login user

--- a/init_config.sh
+++ b/init_config.sh
@@ -124,6 +124,7 @@ write_variable media_id_warning
 write_variable msmtp_args --tls-starttls=off
 write_variable msmtp_auth on
 write_variable msmtp_from
+write_variable msmtp_from_name
 write_variable msmtp_host
 write_variable msmtp_pass
 write_variable msmtp_port

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -2111,9 +2111,9 @@ send_notification()
                   mail_from="\"${mail_from_name}\" <${msmtp_from}>"
             fi
             if [ -n "${msmtp_user}" ] && [ -n "${msmtp_pass}" ]; then
-                  printf "From: %s\nSubject: %s\n\n%s" "${mail_from}" "${notification_message}" "${mail_text}" | msmtp --host="${msmtp_host}" --port="${msmtp_port}" --user="${msmtp_user}" --passwordeval="echo -n ${msmtp_pass}" --from="${msmtp_from}" --auth="${msmtp_auth}" --tls="${msmtp_tls}" $msmtp_args -- "$msmtp_to"
+                  printf "From: %s\nTo: %s\nSubject: %s\n\n%s" "${mail_from}" "${msmtp_to}" "${notification_message}" "${mail_text}" | msmtp --host="${msmtp_host}" --port="${msmtp_port}" --user="${msmtp_user}" --passwordeval="echo -n ${msmtp_pass}" --from="${msmtp_from}" --auth="${msmtp_auth}" --tls="${msmtp_tls}" $msmtp_args -- "$msmtp_to"
             else
-                  printf "From: %s\nSubject: %s\n\n%s" "${mail_from}" "${notification_message}" "${mail_text}" | msmtp --host="${msmtp_host}" --port="${msmtp_port}" --from="${msmtp_from}" --auth="${msmtp_auth}" --tls="${msmtp_tls}" $msmtp_args -- "$msmtp_to"
+                  printf "From: %s\nTo: %s\nSubject: %s\n\n%s" "${mail_from}" "${msmtp_to}" "${notification_message}" "${mail_text}" | msmtp --host="${msmtp_host}" --port="${msmtp_port}" --from="${msmtp_from}" --auth="${msmtp_auth}" --tls="${msmtp_tls}" $msmtp_args -- "$msmtp_to"
             fi
             ;;
          "signal")

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -436,6 +436,10 @@ configure_notifications()
       log_info " | ${notification_type_tc} notifications enabled"
       log_debug "   - ${notification_type_tc} hostname: ${msmtp_host}"
       log_debug "   - ${notification_type_tc} port number: ${msmtp_port}"
+      if [ -n "${msmtp_from_name}" ]
+      then
+         log_debug "   - ${notification_type_tc} from name: ${msmtp_from_name}"
+      fi
       if  [ -n "${msmtp_user}" ] && [ -n "${msmtp_pass}" ]
       then
          log_debug "   - ${notification_type_tc} username: ${msmtp_user}"
@@ -2101,10 +2105,15 @@ send_notification()
             else
                   mail_text="$(echo -e "${notification_icon} ${notification_message}")"
             fi
+            mail_from="${msmtp_from}"
+            if [ -n "${msmtp_from_name}" ]; then
+                  mail_from_name="$(printf "%s" "${msmtp_from_name}" | tr '\r\n' '  ' | sed 's/\\/\\\\/g; s/"/\\"/g')"
+                  mail_from="\"${mail_from_name}\" <${msmtp_from}>"
+            fi
             if [ -n "${msmtp_user}" ] && [ -n "${msmtp_pass}" ]; then
-                  printf "Subject: $notification_message\n\n$mail_text" | msmtp --host=$msmtp_host --port=$msmtp_port --user=$msmtp_user --passwordeval="echo -n $msmtp_pass" --from=$msmtp_from --auth=$msmtp_auth --tls=$msmtp_tls $msmtp_args -- "$msmtp_to"
+                  printf "From: %s\nSubject: %s\n\n%s" "${mail_from}" "${notification_message}" "${mail_text}" | msmtp --host="${msmtp_host}" --port="${msmtp_port}" --user="${msmtp_user}" --passwordeval="echo -n ${msmtp_pass}" --from="${msmtp_from}" --auth="${msmtp_auth}" --tls="${msmtp_tls}" $msmtp_args -- "$msmtp_to"
             else
-                  printf "Subject: $notification_message\n\n$mail_text" | msmtp --host=$msmtp_host --port=$msmtp_port --from=$msmtp_from --auth=$msmtp_auth --tls=$msmtp_tls $msmtp_args -- "$msmtp_to"
+                  printf "From: %s\nSubject: %s\n\n%s" "${mail_from}" "${notification_message}" "${mail_text}" | msmtp --host="${msmtp_host}" --port="${msmtp_port}" --from="${msmtp_from}" --auth="${msmtp_auth}" --tls="${msmtp_tls}" $msmtp_args -- "$msmtp_to"
             fi
             ;;
          "signal")


### PR DESCRIPTION
Adds optional `msmtp_from_name` support for msmtp email notifications, making it easier to identify iCloudPD emails in a crowded inbox.

When configured, msmtp notifications now include a display name in the `From` header:

From: "iCloudPD" <sender@example.com>
To: recipient@example.com

msmtp_from_name is optional to avoid breaking existing msmtp configurations. If it is not set, notifications continue to use the existing sender email address only.