### PR TITLE
Expose `--xmp-sidecar` flag via config

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -116,7 +116,7 @@ adds asset id from iCloud to all file names and does not need de-duplication. De
 
 **video_path**: 
 
-**xmp_sidecar**: Set this to **true** to write an XMP sidecar file (`<filename>.xmp`) alongside each downloaded asset, containing metadata from iCloud not otherwise available locally — including Apple's screenshot classification, keywords, and GPS data. Enabling this on a library that's already fully downloaded will backfill sidecars for existing files on the next sync, not just new downloads — icloudpd evaluates every asset on every sync regardless of whether it re-downloads the media file, and sidecar generation is safe to re-run (it won't overwrite a sidecar it didn't create itself). For live photos, only the still image gets a sidecar; the paired video file does not. Default: false.
+**xmp_sidecar**: Set this to **true** to write a *.xmp sidecar file alongside each downloaded asset. Each sidecar contains metadata from iCloud not otherwise available locally (e.g. screenshot classification). For live photos, only the still image gets a sidecar. Default: false.
 
 # NEXTCLOUD CONFIGURATION ITEMS
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -116,6 +116,8 @@ adds asset id from iCloud to all file names and does not need de-duplication. De
 
 **video_path**: 
 
+**xmp_sidecar**: Set this to **true** to write an XMP sidecar file (`<filename>.xmp`) alongside each downloaded asset, containing metadata from iCloud not otherwise available locally — including Apple's screenshot classification, keywords, and GPS data. Enabling this on a library that's already fully downloaded will backfill sidecars for existing files on the next sync, not just new downloads — icloudpd evaluates every asset on every sync regardless of whether it re-downloads the media file, and sidecar generation is safe to re-run (it won't overwrite a sidecar it didn't create itself). For live photos, only the still image gets a sidecar; the paired video file does not. Default: false.
+
 # NEXTCLOUD CONFIGURATION ITEMS
 
 **nextcloud_delete**: Set this variable to **true** if you want to remove files from Nextcloud. This setting requires **auto_delete** to also be set to true. When a file is found in the 'Recently Deleted', the **auto_delete** function will remove the local file. If **nextcloud_delete** is also set to **true**, then it will remove that file from the Nextcloud server.

--- a/init_config.sh
+++ b/init_config.sh
@@ -187,6 +187,7 @@ write_variable webhook_server
 write_variable wecom_id
 write_variable wecom_proxy
 write_variable wecom_secret
+write_variable xmp_sidecar false
 
 # Set case sensitive variables to lowercase
 notification_type_temp="$(grep -m1 "^notification_type=" "${temp_file}" | cut -d= -f2-)"

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -97,6 +97,7 @@ initialise_script()
    then
       log_info " | Keep iCloud recent : Enabled"
       log_info " | Keep iCloud recent days: ${keep_icloud_recent_days}"
+      log_info " | XMP sidecar: ${xmp_sidecar}"
    fi
    log_info " | Delete empty directories: ${delete_empty_directories}"
    log_info " | Photo size: ${photo_size}"
@@ -2207,6 +2208,10 @@ command_line_builder()
    if [ "${keep_icloud_recent_only}" = "true" ] && [ -n "${keep_icloud_recent_days}" ]
    then
       command_line="${command_line} --keep-icloud-recent-days ${keep_icloud_recent_days}"
+   fi
+   if [ "${xmp_sidecar}" != "false" ]
+   then
+      command_line="${command_line} --xmp-sidecar"
    fi
    if [ "${skip_live_photos}" = "false" ]
    then

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -97,8 +97,8 @@ initialise_script()
    then
       log_info " | Keep iCloud recent : Enabled"
       log_info " | Keep iCloud recent days: ${keep_icloud_recent_days}"
-      log_info " | XMP sidecar: ${xmp_sidecar}"
    fi
+   log_info " | XMP sidecar: ${xmp_sidecar}"
    log_info " | Delete empty directories: ${delete_empty_directories}"
    log_info " | Photo size: ${photo_size}"
    log_info " | Align RAW: ${align_raw}"

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -98,7 +98,7 @@ initialise_script()
       log_info " | Keep iCloud recent : Enabled"
       log_info " | Keep iCloud recent days: ${keep_icloud_recent_days}"
    fi
-   log_info " | XMP sidecar: ${xmp_sidecar}"
+   log_info " | XMP sidecar: ${xmp_sidecar:-false}"
    log_info " | Delete empty directories: ${delete_empty_directories}"
    log_info " | Photo size: ${photo_size}"
    log_info " | Align RAW: ${align_raw}"
@@ -2209,7 +2209,7 @@ command_line_builder()
    then
       command_line="${command_line} --keep-icloud-recent-days ${keep_icloud_recent_days}"
    fi
-   if [ "${xmp_sidecar}" != "false" ]
+   if [ "${xmp_sidecar:-false}" != "false" ]
    then
       command_line="${command_line} --xmp-sidecar"
    fi


### PR DESCRIPTION
Picks up #775.

# Changes
This PR exposes `icloud_photos_downloader`'s `--xmp-sidecar` flag as a new config variable: `xmp_sidecar`. The default setting is `false`.

A sidecar file will look something like this:
```xml
<?xml version='1.0' encoding='utf-8'?>
<x:xml_doc xmlns:x="adobe:ns:meta/" x:xmptk="icloudpd 1.32.3+2035bb1">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
      <dc:description>Screenshot</dc:description>
    </rdf:Description>
    <rdf:Description rdf:about="" xmlns:Iptc4xmpExt="http://iptc.org/std/Iptc4xmpExt/2008-02-29/">
      <Iptc4xmpExt:DigitalSourceType>screenCapture</Iptc4xmpExt:DigitalSourceType>
    </rdf:Description>
    <rdf:Description rdf:about="" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/">
      <photoshop:DateCreated>2026-06-30T12:24:53-0500</photoshop:DateCreated>
    </rdf:Description>
    <rdf:Description rdf:about="" xmlns:tiff="http://ns.adobe.com/tiff/1.0/">
      <tiff:Make>Screenshot</tiff:Make>
    </rdf:Description>
    <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
      <xmp:CreateDate>2026-06-30T12:24:53-0500</xmp:CreateDate>
    </rdf:Description>
  </rdf:RDF>
</x:xml_doc>
```

# Behavior
## Retroactive backfill
If files are already downloaded while the flag is `false`, then it is later turned to `true`, `.xmp` sidecar files will be downloaded for all files already in the library. Critically, this does *not* re-download assets already downloaded; just the sidecars.

## Live Photos
While Live Photos already have two files downloaded for each (`.HEIC` + `.MOV`), only one `.xmp` sidecar is downloaded for one Live Photo. The sidecar counts for both files.

## Deletion
When assets are deleted from iCloud, icloudpd will sync those deletions down to the sidecar as well, leaving no orphaned `.xmp` files.

---

Let me know if any changes are desired here.