### PR TITLE
Update authentication type comment in example.env

### DIFF
--- a/docker-compose/example.env
+++ b/docker-compose/example.env
@@ -11,8 +11,8 @@
 # Apple ID credentials
 #apple_id=
 
-# Authentication type 2FA or Web
-#authentication_type=2FA
+# Authentication type MFA or Web
+#authentication_type=MFA
 
 # Folder structure for downloaded files
 #folder_structure={:%Y/%m/%d}


### PR DESCRIPTION
Healthcheck: 2FA vs MFA

2FA → unhealthy container
MFA → healthy container

The issue appears to be related to healthcheck.sh (line 54):

`if [ "${authentication_type:=MFA}" = "MFA" ]`

First, change 2FA to MFA in the Docker Compose configuration:

`- authentication_type=MFA`

However, this is not enough, because the existing /config/icloudpd.conf still contains the old value:

`authentication_type=2FA`

It must also be changed in the persistent configuration file:

```shell
docker exec <container_name> grep '^authentication_type' /config/icloudpd.conf authentication_type=2FA

sudo sed -i 's/^authentication_type=2FA$/authentication_type=MFA/' <host_config_path>/icloudpd.conf

grep '^authentication_type' <host_config_path>/icloudpd.conf authentication_type=MFA
``` 

After both changes, the container becomes healthy.