### PR TITLE
Fix command execution for non-root users

### DIFF
--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -232,7 +232,7 @@ run_as()
    then
       su "${user}" -s /bin/ash -c "${1}"
    else
-      /bin/ash -c "${command_to_run}"
+      /bin/ash -c "${1}"
    fi
 }
 


### PR DESCRIPTION
The variable `command_to_run` is never set. I'm running icloudpd with a non-root user, and the auth flow is broken otherwise.