### PR TITLE
Fix SMS device index rejected when the keyboard capitalises it, and say how to re-authenticate

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -152,7 +152,7 @@ adds asset id from iCloud to all file names and does not need de-duplication. De
 
 **telegram_silent_file_notifications**: Optional if notification_type set to 'Telegram'. Set this to **true** for the file download notifications to be sent silently. Default = false
 
-**telegram_polling**: Optional if notification_type set to 'Telegram'. Set this to true to enable Telegram polling. This will check the Telegram chat for messages every 60 seconds. If the latest message is the user name, it will synchronise immediately
+**telegram_polling**: Optional if notification_type set to 'Telegram'. Set this to true to enable Telegram polling. This will check the Telegram chat for messages every 60 seconds. If the latest message is the user name, it will synchronise immediately. Sending the user name followed by `auth` starts the re-authentication process, after which the container will ask you for either a trusted device letter or a 6-digit code, which you also send prefixed with the user name. All of these are case insensitive and any extra spaces are ignored, so `boredazfcuk auth` and `Boredazfcuk Auth` do the same thing
 
 **telegram_server**: Optional if notification_type set to 'Telegram'. If Telegram is blocked in your country and you need to use a proxy server to access it, put the fully qualified domain name of the server here. e.g. proxy.server.com
 

--- a/change.log
+++ b/change.log
@@ -1,3 +1,9 @@
+30/08/2026
+
+ - Fixed the remote authentication SMS option being rejected. The message match was already case insensitive, but the device index letter was pulled back out of the original message rather than the lowercased one, so a phone keyboard auto-capitalising it to "A" got sent to iCloudPD, which only accepts "a". Same for the MFA code. Also trimmed and collapsed the whitespace, so a stray trailing space no longer makes the container ignore a perfectly good command.
+ - The multi-factor authentication cookie expiry notification told you to reinitialise but never said how. It now includes the actual instruction - the "<user name> auth" reply if you are on Telegram with polling switched on, or "docker exec -it <container name> reauth.sh" if you are not.
+ - Mentioned the auth, device letter and MFA code messages in the telegram_polling section of CONFIGURATION.md. Only the synchronise message was documented there.
+
 04/05/2026
 
  - Merged PR-941 from seeyabye. This version fixes the Apple modal MFA codes and also works for SMS codes.

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -2425,7 +2425,7 @@ synchronise_user()
                            log_debug "Processing update: ${latest_update}"
                            check_update="$(echo "${latest_updates}" | jq ". | select(.update_id == ${latest_update}).message")"
                            check_update_text="$(echo "${check_update}" | jq -r .text)"
-                           check_update_text_lc="$(echo "${check_update_text}" | tr '[:upper:]' '[:lower:]')"
+                           check_update_text_lc="$(echo "${check_update_text}" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1; print}')"
                            log_debug "New message received: ${check_update_text}"
                            user_lc="$(echo "${user}" | tr '[:upper:]' '[:lower:]')"
                            if [ "${check_update_text_lc}" = "${user_lc}" ]
@@ -2447,7 +2447,7 @@ synchronise_user()
                               poll_sleep=3
                            elif [ "$(expr match "${check_update_text_lc}" "^${user_lc} [0-9][0-9][0-9][0-9][0-9][0-9]$" >/dev/null; echo $?)" -eq 0 ]
                            then
-                              mfa_code="$(echo "${check_update_text}" | awk '{print $2}')"
+                              mfa_code="$(echo "${check_update_text_lc}" | awk '{print $2}')"
                               printf "%s\n" "${mfa_code}" >> /tmp/icloudpd/expect_input.txt
                               listen_counter=$((listen_counter+2))
                               # additional sleeps mean sync time slips each time time a sync or auth is performed
@@ -2457,7 +2457,7 @@ synchronise_user()
                               poll_sleep=30
                            elif [ "$(expr match "${check_update_text_lc}" "^${user_lc} [a-z]$" >/dev/null; echo $?)" -eq 0 ]
                            then
-                              sms_choice="$(echo "${check_update_text}" | awk '{print $2}')"
+                              sms_choice="$(echo "${check_update_text_lc}" | awk '{print $2}')"
                               printf "%s\n" "${sms_choice}" >> /tmp/icloudpd/expect_input.txt
                               listen_counter=$((listen_counter+2))
                               # Same again

--- a/sync-icloud.sh
+++ b/sync-icloud.sh
@@ -781,27 +781,43 @@ check_multifactor_authentication_cookie()
 
 display_multifactor_authentication_expiry()
 {
-   local error_message
+   local error_message reauth_message
    log_info "Multi-factor authentication cookie expires: ${mfa_expire_date/ / @ }"
    log_info "Days remaining until expiration: ${days_remaining}"
    if [ "${days_remaining}" -le "${notification_days}" ]
    then
+      if [ "${notification_type}" = "telegram" ] && [ "${telegram_polling}" = "true" ] && [ -n "${user}" ]
+      then
+         if [ "${icloud_china}" = "false" ]
+         then
+            reauth_message="To re-authenticate now, reply to this chat with: ${user} auth"
+         else
+            reauth_message="如需立即重新验证，请在此对话中回复：${user} auth"
+         fi
+      else
+         if [ "${icloud_china}" = "false" ]
+         then
+            reauth_message="To re-authenticate now, run: docker exec -it <container name> reauth.sh"
+         else
+            reauth_message="如需立即重新验证，请运行：docker exec -it <容器名称> reauth.sh"
+         fi
+      fi
       if [ "${days_remaining}" -eq 1 ]
       then
          cookie_status="cookie expired"
          if [ "${icloud_china}" = "false" ]
          then
-            error_message="Final day before multi-factor authentication cookie expires for Apple ID: ${apple_id} - Please reinitialise now. This is your last reminder"
+            error_message="Final day before multi-factor authentication cookie expires for Apple ID: ${apple_id} - Please reinitialise now. This is your last reminder. ${reauth_message}"
          else
-            error_message="今天是 ${name} 的 Apple ID 两步验证 cookie 到期前的最后一天 - 请立即重新初始化，这是最后的提醒"
+            error_message="今天是 ${name} 的 Apple ID 两步验证 cookie 到期前的最后一天 - 请立即重新初始化，这是最后的提醒。${reauth_message}"
          fi
       else
          cookie_status="cookie expiration"
          if [ "${icloud_china}" = "false" ]
          then
-            error_message="Only ${days_remaining} days until multi-factor authentication cookie expires for Apple ID: ${apple_id} - Please reinitialise"
+            error_message="Only ${days_remaining} days until multi-factor authentication cookie expires for Apple ID: ${apple_id} - Please reinitialise. ${reauth_message}"
          else
-            error_message="${days_remaining} 天后 ${name} 的 Apple ID 两步验证将到期 - 请立即重新初始化"
+            error_message="${days_remaining} 天后 ${name} 的 Apple ID 两步验证将到期 - 请立即重新初始化。${reauth_message}"
          fi
       fi
       log_warning "${error_message}"


### PR DESCRIPTION
Two small usability fixes to the Telegram remote authentication flow, because my phone auto-capitalizes words when I type them and it's been driving me crazy! The code suggests it's meant to be case-insensitive, but there's one place that is not (ie, is sensitive) so the rest is blocked. This makes it consistently case-insensitive. 

1. The SMS device index is rejected when a phone capitalises it

The remote command match has been case insensitive since January 2025, but the device index letter is pulled back out of ${check_update_text} — the original message — rather than ${check_update_text_lc}:

```
sh
elif [ "$(expr match "${check_update_text_lc}" "^${user_lc} [a-z]$" ... )" -eq 0 ]
then
   sms_choice="$(echo "${check_update_text}" | awk '{print $2}')"
```

So the match passes, and then A is written to expect_input.txt and sent to iCloudPD, which prints its device menu with lowercase indices and only accepts a. Both iOS and Android capitalise a standalone letter after a space by default, so this is the common case rather than the edge case. The MFA code path has the same shape; digits make it harmless there, but it is fixed for consistency.

Both extractions now read the lowercased copy.

The same line also gains | awk '{$1=$1; print}', which trims and collapses whitespace. A trailing space was enough to make a valid command fall through to Ignoring message, with nothing in the log unless debug was on.

2. The cookie expiry notification never said how to re-authenticate

It said Please reinitialise and stopped. The procedure is documented in CONFIGURATION.md but is not guessable from the notification itself. It now carries the actual instruction: the <user name> auth reply for installations with telegram_polling enabled, and docker exec -it <container name> reauth.sh for everyone else, including Pushover, Discord, e-mail and the rest.

Both the final-day and the countdown variants are covered.

Also

CONFIGURATION.md mentioned only the synchronise message under telegram_polling. The auth, device letter and MFA code messages are now described there too.

Notes
- No new files, no new dependencies, no change to the polling loop's timing or offset handling.
- build_version.txt is untouched, so this will not trigger a build on merge.
- ShellCheck reports no new findings against master's existing baseline, and bash -n sync-icloud.sh still parses. (dash -n fails on master too, at line 2259 — the script uses ${var//x/y}, which busybox ash supports and dash does not. Not introduced here, but you may want to know your shellcheck failsafe will not catch that class of thing unless it runs with -s dash.)

The Chinese strings are mine (and I do not speak Chinese) and have not been reviewed by a native speaker. I used 重新验证 rather than the 重新初始化 used elsewhere in the file, because reauth.sh re-authenticates rather than re-initialises — but that makes it inconsistent with its neighbours, and you may prefer the existing wording. Happy to change or drop them.
The behaviour was also implemented a second way, as an extracted function with a unit test suite, and the two implementations were run over 45 user/message combinations with zero disagreements. That version is not proposed here — it adds files and is more restructure than you may want. Happy to add it, though.


